### PR TITLE
Fix site bugs and remove unused dependencies

### DIFF
--- a/_data/sale.yml
+++ b/_data/sale.yml
@@ -19,7 +19,7 @@
   register_fee: "Registration is done on a first come first serve basis. We charge a $15 Consignor registration fee (payable through Paypal during the registration process). This fee is non-refundable."
 03_before:
   home: |
-    [Registration](/register/) is open to [Restocking Consignors](/consignors/restocking-consignors/) and [Volunteers](/volunteers) for our [season_year] Sale!
+    [Registration](/register/) is open to [Restocking Consignors](/consignors/restocking-consignors/) and [Volunteers](/volunteers/) for our [season_year] Sale!
 
     Our [[season_year] Sale](/events/) runs [sale_start] through [sale_end] at [Metro Life Church](/events/map-location/)!
   consignors: "[Registration](/register/) is now open for Restocking Consignors."
@@ -40,7 +40,7 @@
   register: "Registration is now closed for [Consignors](/consignors/), but still open for [Volunteers](/volunteers/) for our [season_year] Sale!"
 05_before:
   home: |-
-    [Registration](/register/) is now closed for [Consignors](/consignors/) and [Volunteers](/volunteers) for our [season_year] Sale!
+    [Registration](/register/) is now closed for [Consignors](/consignors/) and [Volunteers](/volunteers/) for our [season_year] Sale!
 
     Our [[season_year] Sale](/events/) runs [sale_start] through [sale_end] at [Metro Life Church](/events/map-location/)!
   consignors: "[Registration](/register/) is now closed."

--- a/_plugins/sale_dates.rb
+++ b/_plugins/sale_dates.rb
@@ -46,7 +46,7 @@ module Jekyll
         'presale' => "#{@presale.strftime('%B %-d')}#{ordinal(@presale.strftime('%-d'))}",
         'moms_night' => "#{@sale_start.strftime('%B %-d')}#{ordinal(@sale_start.strftime('%-d'))} from 8:00 p.m. until 10:00 p.m.",
         'discount_shopping' => "#{@sale_end.strftime('%B %-d')}#{ordinal(@sale_end.strftime('%-d'))} from 2:00 p.m. until 8:00 p.m.",
-        'dropoff' =>  "#{@start_date.strftime('%A, %B %-d')}#{ordinal(@start_date.strftime('%-d'))} from 4:00 p.m. to 9:00 p.m., #{@dropoff.strftime('%A, %B %-d')}#{ordinal(@dropoff.strftime('%-d'))} from 10:00 a.m. to 1:00 p.m. *Restocking Consignors* drop-off Wednesday, April 15th from 12 p.m. to 2 p.m.",
+        'dropoff' =>  "#{@start_date.strftime('%A, %B %-d')}#{ordinal(@start_date.strftime('%-d'))} from 4:00 p.m. to 9:00 p.m., #{@dropoff.strftime('%A, %B %-d')}#{ordinal(@dropoff.strftime('%-d'))} from 10:00 a.m. to 1:00 p.m. *Restocking Consignors* drop-off #{@restocking.strftime('%A, %B %-d')}#{ordinal(@restocking.strftime('%-d'))} from 12 p.m. to 2 p.m.",
         'pickup' => "#{@pickup.strftime('%A, %B %-d')}#{ordinal(@pickup.strftime('%-d'))} from 9:30 a.m. – 12:30 p.m.",
       }
     end

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@fullhuman/postcss-purgecss": "^7.0.0",
     "bootstrap": "^5.3.2",
-    "child_process": "^1.0.2",
     "cssnano": "^7.0.0",
     "fancy-log": "^2.0.0",
     "gulp": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "sass": "^1.69.5"
   },
   "devDependencies": {
-    "gulp-sourcemaps": "^3.0.0",
-    "jquery": "^3.7.1"
+    "gulp-sourcemaps": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- **Fix hardcoded restocking date**: `sale_dates.rb` had a literal "Wednesday, April 15th" for the restocking consignor drop-off instead of using the calculated `@restocking` variable — would show the wrong date every future sale
- **Remove unused `child_process` dependency**: Node.js core module, shouldn't be in package.json
- **Remove unused `jquery` devDependency**: Not used anywhere, Bootstrap 5 doesn't require it
- **Fix missing trailing slashes in `sale.yml`**: Two `/volunteers` links in stages `03_before` and `05_before` were missing trailing slashes

## Test plan
- [ ] Run `bundle exec jekyll build` and verify restocking drop-off date is dynamically generated
- [ ] Run `npm install` and verify no errors from removed dependencies
- [ ] Verify volunteer links render correctly across sale stages