### PR TITLE
Update all GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     name: Jekyll build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -19,18 +19,18 @@ jobs:
           bundler-cache: true
           cache-version: 0
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - name: Run gulp
         run: |
           npm install
           gulp build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
   deploy:
     environment:
       name: github-pages
@@ -40,9 +40,9 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
       - name: Purge cache
-        uses: fishmanlabs/cloudflare-purge-cache-action@v1
+        uses: fishmanlabs/cloudflare-purge-cache-action@v2
         with:
             zone_id: ${{ secrets.CLOUDFLARE_ZONE }}
             api_token: ${{ secrets.CLOUDFLARE_AUTH_KEY }}

--- a/.github/workflows/htmlproofer.yml
+++ b/.github/workflows/htmlproofer.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -17,18 +17,18 @@ jobs:
           bundler-cache: true
           cache-version: 0
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
           cache: 'npm'
       - name: Run gulp
         run: |
           npm install
           gulp build
       - name: HTMLProofer
-        uses: chabad360/htmlproofer@master
+        uses: chabad360/htmlproofer@v2
         with:
           directory: "./_site"
           arguments: "--allow-hash-href --ignore-status-codes 429,999 --ignore-urls '/www.barnesandnobleinc.com/our-stores-communities/summer-reading-program/, /aidinternationalinc.org/, /twitter.com/'"

--- a/.github/workflows/sale-week-updates.yml
+++ b/.github/workflows/sale-week-updates.yml
@@ -18,7 +18,7 @@ jobs:
     name: Jekyll build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -26,11 +26,11 @@ jobs:
           bundler-cache: true
           cache-version: 0
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
           cache: 'npm'
       - name: Install npm packages
         run: npm install
@@ -59,7 +59,7 @@ jobs:
         if: github.event.schedule == '0 17 19 4 *'
         run: JEKYLL_ENV=13_saturday gulp build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
   deploy:
     environment:
       name: github-pages
@@ -69,4 +69,12 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
+      - name: Purge cache
+        uses: fishmanlabs/cloudflare-purge-cache-action@v2
+        with:
+            zone_id: ${{ secrets.CLOUDFLARE_ZONE }}
+            api_token: ${{ secrets.CLOUDFLARE_AUTH_KEY }}
+            purge_everything: 'true'
+            purge_hosts: |
+              boutiqueforaweek.com

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -17,15 +17,15 @@ jobs:
           bundler-cache: true
           cache-version: 0
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
           cache: 'npm'
       - name: Run gulp
         run: |
           npm install
           gulp build
-      - uses: rojopolis/spellcheck-github-actions@0.29.0
+      - uses: rojopolis/spellcheck-github-actions@0.60.0
         name: Check Spelling


### PR DESCRIPTION
## Summary
- **All actions updated** to latest major versions across all 4 workflow files
- **Node.js standardized** to v22 (current LTS) — was inconsistent (18 in 3 files, 20 in 1)
- **HTMLProofer pinned** to `@v2` tag instead of `@master` for stability
- **Cloudflare cache purge added** to sale-week-updates.yml deploy job — was missing, meaning sale week stage changes would serve stale CDN content

### Version updates
| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | v6 |
| actions/configure-pages | v5 | v6 |
| actions/setup-node | v4 | v6 |
| actions/upload-pages-artifact | v3 | v4 |
| actions/deploy-pages | v4 | v5 |
| fishmanlabs/cloudflare-purge-cache-action | v1 | v2 |
| chabad360/htmlproofer | @master | @v2 |
| rojopolis/spellcheck-github-actions | 0.29.0 | 0.60.0 |

## Test plan
- [ ] Verify build workflow runs successfully on merge
- [ ] Verify htmlproofer and spellcheck workflows complete
- [ ] Confirm sale-week-updates deploy now purges Cloudflare cache